### PR TITLE
baikal-xgbe: fixed compilation errors

### DIFF
--- a/drivers/net/ethernet/baikal/xgbe/xgbe-drv.c
+++ b/drivers/net/ethernet/baikal/xgbe/xgbe-drv.c
@@ -1651,8 +1651,10 @@ static void xgbe_poll_controller(struct net_device *netdev)
 
 	if (pdata->per_channel_irq) {
 		channel = pdata->channel;
-		for (i = 0; i < pdata->channel_count; i++, channel++)
-			xgbe_dma_isr(channel->dma_irq, channel);
+		for (i = 0; i < pdata->channel_count; i++, channel++) {
+			xgbe_dma_tx_isr(channel->tx_dma_irq, channel);
+			xgbe_dma_rx_isr(channel->rx_dma_irq, channel);
+		}
 	} else {
 		disable_irq(pdata->dev_irq);
 		xgbe_isr(pdata->dev_irq, pdata);

--- a/drivers/net/ethernet/baikal/xgbe/xgbe-drv.c
+++ b/drivers/net/ethernet/baikal/xgbe/xgbe-drv.c
@@ -1665,11 +1665,17 @@ static void xgbe_poll_controller(struct net_device *netdev)
 }
 #endif /* End CONFIG_NET_POLL_CONTROLLER */
 
-static int xgbe_setup_tc(struct net_device *netdev, u8 tc)
+static int xgbe_setup_tc(struct net_device *netdev, u32 handle, __be16 proto,
+			 struct tc_to_netdev *tc_to_netdev)
 {
 	struct xgbe_prv_data *pdata = netdev_priv(netdev);
 	unsigned int offset, queue;
-	u8 i;
+	u8 tc, i;
+
+	if (tc_to_netdev->type != TC_SETUP_MQPRIO)
+		return -EINVAL;
+
+	tc = tc_to_netdev->tc;
 
 	if (tc && (tc != pdata->hw_feat.tc_cnt))
 		return -EINVAL;

--- a/drivers/net/ethernet/baikal/xgbe/xgbe-mdio.c
+++ b/drivers/net/ethernet/baikal/xgbe/xgbe-mdio.c
@@ -542,11 +542,11 @@ static int be_xgbe_xmit_probe(struct xgbe_prv_data *pdata)
 
 	phydev->speed = SPEED_10000;
 	phydev->duplex = DUPLEX_FULL;
-	phydev->dev.of_node = xmit_node;
+	phydev->mdio.dev.of_node = xmit_node;
 
 	pdata->phydev = phydev;
 	/* refcount is held by phy_attach_direct() on success */
-	put_device(&phydev->dev);
+	put_device(&phydev->mdio.dev);
 
 #if 0
 	/* Add sysfs link to netdevice */


### PR DESCRIPTION
```
drivers/net/ethernet/baikal/xgbe/xgbe-drv.c: In function ‘xgbe_poll_controller’:
drivers/net/ethernet/baikal/xgbe/xgbe-drv.c:1655:4: error: implicit declaration of function ‘xgbe_dma_isr’; did you mean ‘xgbe_dma_rx_isr’? [-Werror=implicit-function-declara
tion]
    xgbe_dma_isr(channel->dma_irq, channel);
    ^~~~~~~~~~~~
    xgbe_dma_rx_isr
drivers/net/ethernet/baikal/xgbe/xgbe-drv.c:1655:26: error: ‘struct xgbe_channel’ has no member named ‘dma_irq’; did you mean ‘tx_dma_irq’?
    xgbe_dma_isr(channel->dma_irq, channel);
                          ^~~~~~~
                          tx_dma_irq
drivers/net/ethernet/baikal/xgbe/xgbe-drv.c: At top level:
drivers/net/ethernet/baikal/xgbe/xgbe-drv.c:1756:19: error: initialization from incompatible pointer type [-Werror=incompatible-pointer-types]
  .ndo_setup_tc  = xgbe_setup_tc,
                   ^~~~~~~~~~~~~
drivers/net/ethernet/baikal/xgbe/xgbe-drv.c:1756:19: note: (near initialization for ‘xgbe_netdev_ops.ndo_setup_tc’)
drivers/net/ethernet/baikal/xgbe/xgbe-mdio.c: In function ‘be_xgbe_xmit_probe’:
drivers/net/ethernet/baikal/xgbe/xgbe-mdio.c:545:10: error: ‘struct phy_device’ has no member named ‘dev’; did you mean ‘drv’?
  phydev->dev.of_node = xmit_node;
          ^~~
          drv
drivers/net/ethernet/baikal/xgbe/xgbe-mdio.c:549:22: error: ‘struct phy_device’ has no member named ‘dev’; did you mean ‘drv’?
  put_device(&phydev->dev);
                      ^~~
                      drv
```

The driver compiles and successfully loads, however I haven't tested if the interface is operational (for I have no other 10Gb NICs/switches)